### PR TITLE
update the tag in catalog manifest + lock to 1.75.2 provider version

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -9,7 +9,7 @@
         "target_terraform",
         "terraform",
         "ai",
-        "chat",
+        "watson",
         "solution"
       ],
       "keywords": [

--- a/solutions/standard/version.tf
+++ b/solutions/standard/version.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.75.1"
+      version = "1.75.2"
     }
   }
 }


### PR DESCRIPTION
### Description

See https://github.com/terraform-ibm-modules/terraform-ibm-watsonx-assistant/issues/29
Not going to an explicit release for this, it will get picked up as part of next release

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
